### PR TITLE
Add real world policy links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ This is an open collaboration between councils, Open Knowledge Australia, and ot
 
 ### How councils can get started
 * Adopt an Open Data policy
-  - Download and adapt a template policy (links to come)
+  - Download and adapt a template policy:
+    * [City of Melbourne's Open Data Principles and Program](https://www.melbourne.vic.gov.au/getinvolved/Pages/opendata.aspx) 
+    * [data.gov.au's policy wiki](https://toolkit.data.gov.au/index.php?title=Policy#Policies)
+    * [International Open Data Charter](http://opendatacharter.net/) 
 * [Create a data.gov.au account](https://toolkit.data.gov.au/index.php?title=Starting_on_datagovau#Getting_an_Account)
 * Use tools to automatically extract and upload data
   - FME workspaces


### PR DESCRIPTION
Fix #31 with placeholder links.

https://www.surveymonkey.com/results/SM-CYY5HQFC/ suggested a number of people were blocked due to a lack of policy. We don't have a sample policy yet, so in goes the rough and ready links :)

@Will-mac ; reckon it would be possible to get the resources linked to for the City of Melbourne open data principles, etc explicitly/obviously licensed as CC-BY 3.0 (http://creativecommons.org/licenses/by/3.0/au/)?

http://creativecommons.org/choose/ is handy and produces a nice image plus link; like:

![Creative Commons Licence](https://i.creativecommons.org/l/by/3.0/au/88x31.png)
This work is licensed under a [Creative Commons Attribution 3.0 Australia License](http://creativecommons.org/licenses/by/3.0/au/).

HTML:

```
<a rel="license" href="http://creativecommons.org/licenses/by/3.0/au/"><img alt="Creative Commons Licence" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/au/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/3.0/au/">Creative Commons Attribution 3.0 Australia License</a>.
```
